### PR TITLE
Add plan dict to Azure template only if needed

### DIFF
--- a/templates/cloud_vpn/provisioners/azure/initiator/provision.j2
+++ b/templates/cloud_vpn/provisioners/azure/initiator/provision.j2
@@ -158,7 +158,7 @@
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
-{% if cloud_vpn_initiator_azure_image_needs_plan %}
+{% if cloud_vpn_initiator_azure_image_needs_plan|default(False) %}
       "plan": {
         "name": "{{ cloud_vpn_initiator_azure_image_sku }}",
         "publisher": "{{ cloud_vpn_initiator_azure_image_publisher }}",

--- a/templates/cloud_vpn/provisioners/azure/initiator/provision.j2
+++ b/templates/cloud_vpn/provisioners/azure/initiator/provision.j2
@@ -158,11 +158,13 @@
       "type": "Microsoft.Compute/virtualMachines",
       "name": "[variables('vmName')]",
       "location": "[parameters('location')]",
+{% if cloud_vpn_initiator_azure_image_needs_plan %}
       "plan": {
         "name": "{{ cloud_vpn_initiator_azure_image_sku }}",
         "publisher": "{{ cloud_vpn_initiator_azure_image_publisher }}",
         "product": "{{ cloud_vpn_initiator_azure_image_offer }}"
       },
+{% endif %}
       "dependsOn": [
         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
         "[resourceId('Microsoft.Network/networkInterfaces/', '{{ cloud_vpn_name }}-initiator-network-interface')]",


### PR DESCRIPTION
Images like RHEL which are free do not need a plan, the API returns a bogus error
if passed in as if the image needs marketplace programmatic access, but reality is
passing the dict is the issue.
Will probably add a task later on to infer this var by querying image facts, for now
user can just pass cloud_vpn_initiator_azure_image_needs_plan var to True work it around.